### PR TITLE
refactor: renamed gswagger.New to gswagger.NewRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An example usage of this lib:
 ```go
 context := context.Background()
 r := mux.NewRouter()
-router, _ := gswagger.New(r, gswagger.Options{
+router, _ := gswagger.NewRouter(r, gswagger.Options{
   Context: context,
   Openapi: &openapi3.Swagger{
     Info: &openapi3.Info{

--- a/integration_test.go
+++ b/integration_test.go
@@ -61,7 +61,7 @@ func setupSwagger(t *testing.T) *mux.Router {
 	context := context.Background()
 	muxRouter := mux.NewRouter()
 
-	router, err := New(muxRouter, Options{
+	router, err := NewRouter(muxRouter, Options{
 		Context: context,
 		Openapi: &openapi3.Swagger{
 			Info: &openapi3.Info{

--- a/main.go
+++ b/main.go
@@ -36,8 +36,8 @@ type Options struct {
 	Openapi *openapi3.Swagger
 }
 
-// New generate new router with swagger. Default to OpenAPI 3.0.0
-func New(router *mux.Router, options Options) (*Router, error) {
+// NewRouter generate new router with swagger. Default to OpenAPI 3.0.0
+func NewRouter(router *mux.Router, options Options) (*Router, error) {
 	swagger, err := generateNewValidSwagger(options.Openapi)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrValidatingSwagger, err)

--- a/main_test.go
+++ b/main_test.go
@@ -27,14 +27,14 @@ func TestNewRouter(t *testing.T) {
 	}
 
 	t.Run("not ok - invalid Openapi option", func(t *testing.T) {
-		r, err := New(mRouter, Options{})
+		r, err := NewRouter(mRouter, Options{})
 
 		require.Nil(t, r)
 		require.EqualError(t, err, fmt.Sprintf("%s: swagger is required", ErrValidatingSwagger))
 	})
 
 	t.Run("ok - with default context", func(t *testing.T) {
-		r, err := New(mRouter, Options{
+		r, err := NewRouter(mRouter, Options{
 			Openapi: openapi,
 		})
 
@@ -49,7 +49,7 @@ func TestNewRouter(t *testing.T) {
 	t.Run("ok - with custom context", func(t *testing.T) {
 		type key struct{}
 		ctx := context.WithValue(context.Background(), key{}, "value")
-		r, err := New(mRouter, Options{
+		r, err := NewRouter(mRouter, Options{
 			Openapi: openapi,
 			Context: ctx,
 		})
@@ -132,7 +132,7 @@ func TestGenerateValidSwagger(t *testing.T) {
 func TestGenerateAndExposeSwagger(t *testing.T) {
 	t.Run("fails swagger validation", func(t *testing.T) {
 		mRouter := mux.NewRouter()
-		router, err := New(mRouter, Options{
+		router, err := NewRouter(mRouter, Options{
 			Openapi: &openapi3.Swagger{
 				Info: &openapi3.Info{
 					Title:   "title",
@@ -158,7 +158,7 @@ func TestGenerateAndExposeSwagger(t *testing.T) {
 		swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromFile("testdata/users_employees.json")
 		require.NoError(t, err)
 
-		router, err := New(mRouter, Options{
+		router, err := NewRouter(mRouter, Options{
 			Openapi: swagger,
 		})
 

--- a/route_test.go
+++ b/route_test.go
@@ -263,7 +263,7 @@ func TestAddRoute(t *testing.T) {
 			context := context.Background()
 			r := mux.NewRouter()
 
-			router, err := New(r, Options{
+			router, err := NewRouter(r, Options{
 				Context: context,
 				Openapi: getBaseSwagger(t),
 			})
@@ -458,7 +458,7 @@ func TestResolveRequestBodySchema(t *testing.T) {
 	}
 
 	mux := mux.NewRouter()
-	router, err := New(mux, Options{
+	router, err := NewRouter(mux, Options{
 		Openapi: getBaseSwagger(t),
 	})
 	require.NoError(t, err)
@@ -601,7 +601,7 @@ func TestResolveResponsesSchema(t *testing.T) {
 	}
 
 	mux := mux.NewRouter()
-	router, err := New(mux, Options{
+	router, err := NewRouter(mux, Options{
 		Openapi: getBaseSwagger(t),
 	})
 	require.NoError(t, err)
@@ -771,7 +771,7 @@ func TestResolveParametersSchema(t *testing.T) {
 	}
 
 	mux := mux.NewRouter()
-	router, err := New(mux, Options{
+	router, err := NewRouter(mux, Options{
 		Openapi: getBaseSwagger(t),
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
This resolves one of the requests in road to initial release issue #4 