### PR TITLE
Verify anyOf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Formats `date-time`, `email`, `hostname`, `ipv4`, `ipv6`, `uri` could be added w
 1. How to add a swagger with `allOf`?
 You can create manually a swagger with `allOf` using the `AddRawRoute` method.
 
+1. How to add a swagger with `anyOf`?
+You can create manually a swagger with `anyOf` using the `AddRawRoute` method.
+
 #### Discovered unsupported schema features
 
 *Formats*:

--- a/route_test.go
+++ b/route_test.go
@@ -293,13 +293,57 @@ func TestAddRoutes(t *testing.T) {
 					},
 				}
 				responseNested := openapi3.NewResponse().WithJSONSchema(nestedSchema)
-				nestedAllOperation := NewOperation()
-				nestedAllOperation.AddResponse(200, responseNested)
+				nestedAllOfOperation := NewOperation()
+				nestedAllOfOperation.AddResponse(200, responseNested)
 
-				_, err = router.AddRawRoute(http.MethodGet, "/nested-schema", okHandler, nestedAllOperation)
+				_, err = router.AddRawRoute(http.MethodGet, "/nested-schema", okHandler, nestedAllOfOperation)
 				require.NoError(t, err)
 			},
 			fixturesPath: "testdata/allof.json",
+		},
+		{
+			name: "anyOf schema",
+			routes: func(t *testing.T, router *Router) {
+				schema := openapi3.NewAnyOfSchema()
+				schema.AnyOf = []*openapi3.SchemaRef{
+					{
+						Value: openapi3.NewFloat64Schema().
+							WithMin(1).
+							WithMax(2),
+					},
+					{
+						Value: openapi3.NewFloat64Schema().
+							WithMin(2).
+							WithMax(3),
+					},
+				}
+				request := openapi3.NewRequestBody().WithJSONSchema(schema)
+				response := openapi3.NewResponse().WithJSONSchema(schema)
+
+				allOperation := NewOperation()
+				allOperation.AddResponse(200, response)
+				allOperation.AddRequestBody(request)
+
+				_, err := router.AddRawRoute(http.MethodPost, "/any-of", okHandler, allOperation)
+				require.NoError(t, err)
+
+				nestedSchema := openapi3.NewSchema()
+				nestedSchema.Properties = map[string]*openapi3.SchemaRef{
+					"foo": {
+						Value: openapi3.NewStringSchema(),
+					},
+					"nested": {
+						Value: schema,
+					},
+				}
+				responseNested := openapi3.NewResponse().WithJSONSchema(nestedSchema)
+				nestedAnyOfOperation := NewOperation()
+				nestedAnyOfOperation.AddResponse(200, responseNested)
+
+				_, err = router.AddRawRoute(http.MethodGet, "/nested-schema", okHandler, nestedAnyOfOperation)
+				require.NoError(t, err)
+			},
+			fixturesPath: "testdata/anyof.json",
 		},
 	}
 

--- a/testdata/anyof.json
+++ b/testdata/anyof.json
@@ -1,0 +1,91 @@
+{
+  "components": {},
+  "info": {
+    "title": "test swagger title",
+    "version": "test swagger version"
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/any-of": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "maximum": 2,
+                    "minimum": 1,
+                    "type": "number"
+                  },
+                  {
+                    "maximum": 3,
+                    "minimum": 2,
+                    "type": "number"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "maximum": 2,
+                      "minimum": 1,
+                      "type": "number"
+                    },
+                    {
+                      "maximum": 3,
+                      "minimum": 2,
+                      "type": "number"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/nested-schema": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "foo": {
+                      "type": "string"
+                    },
+                    "nested": {
+                      "anyOf": [
+                        {
+                          "maximum": 2,
+                          "minimum": 1,
+                          "type": "number"
+                        },
+                        {
+                          "maximum": 3,
+                          "minimum": 2,
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
In this PR are added tests to verify the support of oas keyword `anyOf`.
We support this only using the AddRawRoute method, since it is not clear how we can inherit with struct (it is not supported by [jsonschema](https://github.com/alecthomas/jsonschema) lib)