### PR TITLE
Set method as first parameter of AddRoute function in Router interface

### DIFF
--- a/apirouter/gorilla.go
+++ b/apirouter/gorilla.go
@@ -6,7 +6,7 @@ type gorillaRouter struct {
 	router *mux.Router
 }
 
-func (r gorillaRouter) AddRoute(path string, method string, handler HandlerFunc) Route {
+func (r gorillaRouter) AddRoute(method string, path string, handler HandlerFunc) Route {
 	return r.router.HandleFunc(path, handler).Methods(method)
 }
 

--- a/apirouter/gorilla_test.go
+++ b/apirouter/gorilla_test.go
@@ -18,7 +18,7 @@ func TestGorillaMuxRouter(t *testing.T) {
 	})
 
 	t.Run("add new route", func(t *testing.T) {
-		route := ar.AddRoute("/foo", http.MethodGet, func(w http.ResponseWriter, req *http.Request) {
+		route := ar.AddRoute(http.MethodGet, "/foo", func(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(200)
 			w.Write(nil)
 		})

--- a/apirouter/router.go
+++ b/apirouter/router.go
@@ -6,7 +6,7 @@ import "net/http"
 type HandlerFunc func(w http.ResponseWriter, req *http.Request)
 
 type Router interface {
-	AddRoute(path string, method string, handler HandlerFunc) Route
+	AddRoute(method string, path string, handler HandlerFunc) Route
 }
 
 type Route interface{}

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func (r Router) GenerateAndExposeSwagger() error {
 	if err != nil {
 		return fmt.Errorf("%w json marshal: %s", ErrGenerateSwagger, err)
 	}
-	r.router.AddRoute(r.jsonDocumentationPath, http.MethodGet, func(w http.ResponseWriter, req *http.Request) {
+	r.router.AddRoute(http.MethodGet, r.jsonDocumentationPath, func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write(jsonSwagger)
@@ -149,7 +149,7 @@ func (r Router) GenerateAndExposeSwagger() error {
 	if err != nil {
 		return fmt.Errorf("%w yaml marshal: %s", ErrGenerateSwagger, err)
 	}
-	r.router.AddRoute(r.yamlDocumentationPath, http.MethodGet, func(w http.ResponseWriter, req *http.Request) {
+	r.router.AddRoute(http.MethodGet,r.yamlDocumentationPath, func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
 		w.Write(yamlSwagger)

--- a/route.go
+++ b/route.go
@@ -41,7 +41,7 @@ func (r Router) AddRawRoute(method string, routePath string, handler apirouter.H
 	r.swaggerSchema.AddOperation(pathWithPrefix, method, op)
 
 	// Handle, when content-type is json, the request/response marshalling? Maybe with a specific option.
-	return r.router.AddRoute(pathWithPrefix, method, handler), nil
+	return r.router.AddRoute(method, pathWithPrefix, handler), nil
 }
 
 // Content is the type of a content.


### PR DESCRIPTION
## Changes

- modified Router interface by sorting `addRoute` method arguments in a different manner

## Reason

The purpose of this PR is to align the `addRoute` signature of Router interface to the one employed in the swagger package of this repository.  
In addition, setting the method argument as the first one in the signature would resembles what happens in other web frameworks. Indeed, they usually employ a function named as the HTTP method with the route path as first parameter.

As a clarification the newer interface:

```
router.addRoute("GET", "/path", ...)
```
would be similar to the style adopter by other frameworks:

```
router.Get("/path", ...)
```

Examples of frameworks using this approach are:

- [go-chi](https://go-chi.io/#/pages/getting_started)
- [echo](https://echo.labstack.com/guide/)
- [fiber](https://docs.gofiber.io/)
- [miabase](https://github.com/danibix95/miabase)
- [custom-plugin-lib](https://github.com/mia-platform/custom-plugin-lib/)
